### PR TITLE
Issue #43: Rename check constraints with duplicate name

### DIFF
--- a/src-db/database/model/modifiedTables/JOBS_JOB.xml
+++ b/src-db/database/model/modifiedTables/JOBS_JOB.xml
@@ -21,7 +21,7 @@
         <default><![CDATA[N]]></default>
         <onCreateDefault/>
       </column>
-      <check name="EM_ETAP_CONS_PER_PART_CHK"><![CDATA[EM_ETAP_CONS_PER_PART = 'Y' OR EM_ETAP_CONS_PER_PART = 'N']]></check>
+      <check name="EM_ETAP_CONS_PER_PART_JB_CHK"><![CDATA[EM_ETAP_CONS_PER_PART = 'Y' OR EM_ETAP_CONS_PER_PART = 'N']]></check>
       <check name="EM_ETAP_ISASYNC_CHK"><![CDATA[EM_ETAP_ISASYNC = 'Y' OR EM_ETAP_ISASYNC = 'N']]></check>
       <check name="EM_ETAP_ISREGULAREXP_CHK"><![CDATA[EM_ETAP_ISREGULAREXP = 'Y' OR EM_ETAP_ISREGULAREXP = 'N']]></check>
     </table>

--- a/src-db/database/model/modifiedTables/JOBS_JOBLINE.xml
+++ b/src-db/database/model/modifiedTables/JOBS_JOBLINE.xml
@@ -13,6 +13,6 @@
         <default><![CDATA[N]]></default>
         <onCreateDefault/>
       </column>
-      <check name="EM_ETAP_CONS_PER_PART_CHK"><![CDATA[EM_ETAP_CONS_PER_PART = 'Y' OR EM_ETAP_CONS_PER_PART = 'N']]></check>
+      <check name="EM_ETAP_CONS_PER_PART_JBL_CHK"><![CDATA[EM_ETAP_CONS_PER_PART = 'Y' OR EM_ETAP_CONS_PER_PART = 'N']]></check>
     </table>
   </database>


### PR DESCRIPTION
ETP-2037: Renamed check constraints for consistency:
- JOBS_JOB: EM_ETAP_CONS_PER_PART_CHK to EM_ETAP_CONS_PER_PART_JB_CHK
- JOBS_JOBLINE: EM_ETAP_CONS_PER_PART_CHK to EM_ETAP_CONS_PER_PART_JBL_CHK